### PR TITLE
Add custom endpoint for a specific palette by name and happy / sad te…

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,17 @@ app.get('/api/v1/projects', async (request, response) => {
 
 app.get('/api/v1/palettes', async (request, response) => {
   const palettes = await database('palettes').select();
+  const { palette_name } = request.query
+  if(palette_name) {
+    const foundPalette = await database('palettes').where('palette_name', request.query.palette_name);
+    if(foundPalette.length) {
+      return response.status(200).json(foundPalette)
+    } else {
+      return response.status(404).json({ error: 'That palette does not exist' })
+    }    
+  }
   return response.status(200).json(palettes)
+  
 });
 
 app.get('/api/v1/projects/:id', async (request, response) => {

--- a/app.test.js
+++ b/app.test.js
@@ -265,4 +265,16 @@ describe('Server', () => {
       expect(response.status).toBe(422);
      });
   });
+
+  describe('GET, custom endpoint -- /api/v1/palettes?palette_name=:name', () => {
+    it('should return a palette with the specified name', async () => {
+      const palette = await database('palettes').first()
+      const paletteName = palette.palette_name;
+      
+      const response = await request(app).get(`/api/v1/palettes?palette_name=${paletteName}`);
+      
+      expect(response.status).toBe(200);
+      expect(JSON.stringify(response.body)).toEqual(JSON.stringify([palette]))
+    })
+  })
 });


### PR DESCRIPTION
…sts for said endpoint

## What does this PR do?
- This PR adds a custom endpoint for our users. They can now search a palette by name and receive an entire palette

## Where should the reviewer start? 
- line 268 of app.test

## How should this be manually tested
- ```npm test```

## What are the relevant tickets
- Set up custom endpoint (id: 22)